### PR TITLE
Fix example documentation comment in 3L.less

### DIFF
--- a/3L/3L.less
+++ b/3L/3L.less
@@ -770,7 +770,7 @@
 // * @EXAMPLES
 // * 1. .scale(2,.5) // Stretch an object two times and shrink in height by half.
 // * 2. .rotate(180deg) // Rotate an object by 180deg.
-// * 3. .transform(.scale(2,.5),rotate(180deg)) // Does the combined transformation from examples above.
+// * 3. .transform(scale(2,.5) rotate(180deg)) // Does the combined transformation from examples above.
 // * 4. .transform-origin(20% top) // Place the transformation origin at the top, 20% of the object's
 // * 							   // width to the right from the top-left corner. 
 // * 	


### PR DESCRIPTION
Fixed wrong syntax in .transform(.scale(2,.5),rotate(180deg)); that doesn't work. .transform(scale(2,.5) rotate(180deg)); will do it.
